### PR TITLE
gRPC Taks fixes to work with Python 3.7

### DIFF
--- a/src/main/kotlin/com/innobead/gradle/plugin/PythonPlugin.kt
+++ b/src/main/kotlin/com/innobead/gradle/plugin/PythonPlugin.kt
@@ -24,16 +24,13 @@ class PythonPlugin : Plugin<Project> {
         )
     }
 
-
     override fun apply(project: Project?) {
         with(project!!) {
-
             apply(mapOf("plugin" to "base"))
 
             extensions.create("python", PythonPluginExtension::class.java, this)
 
             logger.debug("Creating $builtinTasks tasks")
-
             builtinTasks.forEach {
                 project.tasks.create(it.taskName, it.java)
             }

--- a/src/main/kotlin/com/innobead/gradle/plugin/PythonPlugin.kt
+++ b/src/main/kotlin/com/innobead/gradle/plugin/PythonPlugin.kt
@@ -28,16 +28,13 @@ class PythonPlugin : Plugin<Project> {
     override fun apply(project: Project?) {
         with(project!!) {
 
-            val disabledTasks by lazy {
-                project.extensions.pythonPluginExtension.disabledTasks
-            }
-
             apply(mapOf("plugin" to "base"))
 
             extensions.create("python", PythonPluginExtension::class.java, this)
 
             logger.debug("Creating $builtinTasks tasks")
-            builtinTasks.filterNot { disabledTasks.contains(it.taskName) }.forEach {
+
+            builtinTasks.forEach {
                 project.tasks.create(it.taskName, it.java)
             }
 

--- a/src/main/kotlin/com/innobead/gradle/plugin/PythonPlugin.kt
+++ b/src/main/kotlin/com/innobead/gradle/plugin/PythonPlugin.kt
@@ -24,14 +24,20 @@ class PythonPlugin : Plugin<Project> {
         )
     }
 
+
     override fun apply(project: Project?) {
         with(project!!) {
+
+            val disabledTasks by lazy {
+                project.extensions.pythonPluginExtension.disabledTasks
+            }
+
             apply(mapOf("plugin" to "base"))
 
             extensions.create("python", PythonPluginExtension::class.java, this)
 
             logger.debug("Creating $builtinTasks tasks")
-            builtinTasks.forEach {
+            builtinTasks.filterNot { disabledTasks.contains(it.taskName) }.forEach {
                 project.tasks.create(it.taskName, it.java)
             }
 

--- a/src/main/kotlin/com/innobead/gradle/plugin/PythonPluginExtension.kt
+++ b/src/main/kotlin/com/innobead/gradle/plugin/PythonPluginExtension.kt
@@ -82,4 +82,8 @@ class PythonPluginExtension(val project: Project) {
 
     var pipOptions: String = ""
 
+    var grpcVersion: String = "1.7.0"
+
+    var disabledTasks: Set<String> = setOf()
+
 }

--- a/src/main/kotlin/com/innobead/gradle/plugin/PythonPluginExtension.kt
+++ b/src/main/kotlin/com/innobead/gradle/plugin/PythonPluginExtension.kt
@@ -84,6 +84,6 @@ class PythonPluginExtension(val project: Project) {
 
     var grpcVersion: String = "1.7.0"
 
-    var disabledTasks: Set<String> = setOf()
+    var disableGrpc:Boolean = false
 
 }

--- a/src/main/kotlin/com/innobead/gradle/task/PythonGrpcTask.kt
+++ b/src/main/kotlin/com/innobead/gradle/task/PythonGrpcTask.kt
@@ -28,6 +28,10 @@ class PythonGrpcTask : AbstractTask() {
         project.extensions.pythonPluginExtension.pipOptions
     }
 
+    val grpcVersion by lazy {
+        project.extensions.pythonPluginExtension.grpcVersion
+    }
+
     init {
         group = PythonPlugin.name
         description = "Build gRPC Python client code"
@@ -43,7 +47,7 @@ class PythonGrpcTask : AbstractTask() {
         logger.lifecycle("Building gRPC Python client code based on the proto files from ${protoSourceDirs}")
 
         val commands = listOf(
-                "python -m pip install grpcio==1.7.0 grpcio-tools==1.7.0 $pipOptions",
+                "python -m pip install grpcio==$grpcVersion grpcio-tools==$grpcVersion $pipOptions",
                 "python -m grpc_tools.protoc ${protoSourceDirs!!.map { "-I$it" }.joinToString(" ")} " +
                         "--python_out=$protoCodeGeneratedDir " +
                         "--grpc_python_out=$protoCodeGeneratedDir ${protoServiceProtoFiles!!.joinToString(" ")}"

--- a/src/main/kotlin/com/innobead/gradle/task/PythonGrpcTask.kt
+++ b/src/main/kotlin/com/innobead/gradle/task/PythonGrpcTask.kt
@@ -32,6 +32,11 @@ class PythonGrpcTask : AbstractTask() {
         project.extensions.pythonPluginExtension.grpcVersion
     }
 
+    val disableGrpc by lazy {
+        project.extensions.pythonPluginExtension.disableGrpc
+    }
+
+
     init {
         group = PythonPlugin.name
         description = "Build gRPC Python client code"
@@ -44,24 +49,28 @@ class PythonGrpcTask : AbstractTask() {
 
     @TaskAction
     fun action() {
-        logger.lifecycle("Building gRPC Python client code based on the proto files from ${protoSourceDirs}")
+        if(disableGrpc){
+            logger.lifecycle("Skipping gRPC task due to the config")
+        } else {
+            logger.lifecycle("Building gRPC Python client code based on the proto files from ${protoSourceDirs}")
 
-        val commands = listOf(
-                "python -m pip install grpcio==$grpcVersion grpcio-tools==$grpcVersion $pipOptions",
-                "python -m grpc_tools.protoc ${protoSourceDirs!!.map { "-I$it" }.joinToString(" ")} " +
-                        "--python_out=$protoCodeGeneratedDir " +
-                        "--grpc_python_out=$protoCodeGeneratedDir ${protoServiceProtoFiles!!.joinToString(" ")}"
-        )
+            val commands = listOf(
+                    "python -m pip install grpcio==$grpcVersion grpcio-tools==$grpcVersion $pipOptions",
+                    "python -m grpc_tools.protoc ${protoSourceDirs!!.map { "-I$it" }.joinToString(" ")} " +
+                            "--python_out=$protoCodeGeneratedDir " +
+                            "--grpc_python_out=$protoCodeGeneratedDir ${protoServiceProtoFiles!!.joinToString(" ")}"
+            )
 
-        protoCodeGeneratedDir!!.mkdirs()
-        File(protoCodeGeneratedDir, "__init__.py").createNewFile()
+            protoCodeGeneratedDir!!.mkdirs()
+            File(protoCodeGeneratedDir, "__init__.py").createNewFile()
 
-        project.exec {
-            it.isIgnoreExitValue = true
-            it.commandLine(listOf(
-                    "bash", "-c",
-                    "source $virtualenvDir/bin/activate; ${commands.joinToString(";")}"
-            ))
+            project.exec {
+                it.isIgnoreExitValue = true
+                it.commandLine(listOf(
+                        "bash", "-c",
+                        "source $virtualenvDir/bin/activate; ${commands.joinToString(";")}"
+                ))
+            }
         }
     }
 


### PR DESCRIPTION
Currently, due to the hardcoded gRPC dependencies the plugin doesn't work with python 3.7.
I've added two new configuration params:

-  `disableGrpc`  boolean (default false)
-  `grpcVersion` string, default `1.7.0` but you have to set it to `1.21.0` to work with python 3.7