### PR TITLE
Cache build files

### DIFF
--- a/src/main/kotlin/com/innobead/gradle/plugin/PythonPluginExtension.kt
+++ b/src/main/kotlin/com/innobead/gradle/plugin/PythonPluginExtension.kt
@@ -73,6 +73,7 @@ class PythonPluginExtension(val project: Project) {
             return dir
         }
 
+    var keepBuildCached:Boolean = false
 
     var pypiRepoUrl: String? = null
 

--- a/src/main/kotlin/com/innobead/gradle/task/PythonDependenciesTask.kt
+++ b/src/main/kotlin/com/innobead/gradle/task/PythonDependenciesTask.kt
@@ -37,9 +37,9 @@ class PythonDependenciesTask : AbstractTask() {
             return
         }
 
-        val f = File( "build")
+        val f = File( "build/.requirements")
 
-        if(keepBuildCached && f.exists() && f.isDirectory){
+        if(keepBuildCached && f.exists()){
             logger.lifecycle("Ignored to install dependencies, because build directory is already present")
             return
         }
@@ -74,6 +74,12 @@ class PythonDependenciesTask : AbstractTask() {
                 }
             }
         }
+
+        project.exec {
+            it.commandLine(listOf(
+                    "bash", "-c", "touch build/.requirements"
+            ))
+        }.rethrowFailure()
     }
 
 }

--- a/src/main/kotlin/com/innobead/gradle/task/PythonDependenciesTask.kt
+++ b/src/main/kotlin/com/innobead/gradle/task/PythonDependenciesTask.kt
@@ -15,6 +15,10 @@ class PythonDependenciesTask : AbstractTask() {
         project.extensions.pythonPluginExtension.pipOptions
     }
 
+    val keepBuildCached by lazy {
+        project.extensions.pythonPluginExtension.keepBuildCached
+    }
+
     var copyLibsDir: File? = null
 
     init {
@@ -30,6 +34,11 @@ class PythonDependenciesTask : AbstractTask() {
     fun action() {
         if (!project.file("requirements.txt").exists()) {
             logger.lifecycle("Ignored to install dependencies, because requirements.txt not found")
+            return
+        }
+
+        if(keepBuildCached && project.file("build").exists()){
+            logger.lifecycle("Ignored to install dependencies, because build directory is already present")
             return
         }
 

--- a/src/main/kotlin/com/innobead/gradle/task/PythonDependenciesTask.kt
+++ b/src/main/kotlin/com/innobead/gradle/task/PythonDependenciesTask.kt
@@ -37,14 +37,14 @@ class PythonDependenciesTask : AbstractTask() {
             return
         }
 
-        val f = File( "build/.requirements")
+        val f =  File(project.buildDir, ".requirements")
 
         if(keepBuildCached && f.exists()){
-            logger.lifecycle("Ignored to install dependencies, because build directory is already present")
+            logger.lifecycle("Ignored to install dependencies, because requirements flag is set")
             return
         }
 
-        logger.lifecycle("Installing dependencies in requirements.txt")
+        logger.lifecycle("Installing dependencies in requirements.txt ${f.exists()} ")
 
         project.exec {
             it.commandLine(listOf(
@@ -75,11 +75,7 @@ class PythonDependenciesTask : AbstractTask() {
             }
         }
 
-        project.exec {
-            it.commandLine(listOf(
-                    "bash", "-c", "touch build/.requirements"
-            ))
-        }.rethrowFailure()
+       f.createNewFile()
     }
 
 }

--- a/src/main/kotlin/com/innobead/gradle/task/PythonDependenciesTask.kt
+++ b/src/main/kotlin/com/innobead/gradle/task/PythonDependenciesTask.kt
@@ -37,7 +37,9 @@ class PythonDependenciesTask : AbstractTask() {
             return
         }
 
-        if(keepBuildCached && project.file("build").exists()){
+        val f = File( "build")
+
+        if(keepBuildCached && f.exists() && f.isDirectory){
             logger.lifecycle("Ignored to install dependencies, because build directory is already present")
             return
         }


### PR DESCRIPTION
Added new property `keepBuildCached` when set to true it will keep the `build` directory cached rather than populating it each time one invokes gradle command. 
@innobead  