### PR TITLE
Added pythonExecutable parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ python {
     pypiRepoUrl = 'https://pypi.python.org/simple/'
     pypiRepoUsername = 'admin'
     pypiRepoPassword = 'admin123'
+    disableGrpc = false // set true to disable Grpc task
+    keepBuildCached = false // set true to skip generation of build directory once already created
+    pythonExecutable = "python" // adjust python executable name
 }
 
 ```

--- a/src/main/kotlin/com/innobead/gradle/plugin/PythonPluginExtension.kt
+++ b/src/main/kotlin/com/innobead/gradle/plugin/PythonPluginExtension.kt
@@ -87,4 +87,5 @@ class PythonPluginExtension(val project: Project) {
 
     var disableGrpc: Boolean = false
 
+    var pythonExecutable: String = "python"
 }

--- a/src/main/kotlin/com/innobead/gradle/task/AbstractTask.kt
+++ b/src/main/kotlin/com/innobead/gradle/task/AbstractTask.kt
@@ -18,6 +18,10 @@ abstract class AbstractTask : DefaultTask() {
         project.extensions.pythonPluginExtension.pythonBuildDir
     }
 
+    val pythonExecutable by lazy {
+        project.extensions.pythonPluginExtension.pythonExecutable
+    }
+
     fun preparePythonEnv(commands: MutableList<String>) {
         commands.clear()
 

--- a/src/main/kotlin/com/innobead/gradle/task/PythonBuildTask.kt
+++ b/src/main/kotlin/com/innobead/gradle/task/PythonBuildTask.kt
@@ -45,7 +45,7 @@ class PythonBuildTask : AbstractTask() {
 
     @TaskAction
     fun action() {
-        val commands = mutableListOf("python -m pip install wheel")
+        val commands = mutableListOf("$pythonExecutable -m pip install wheel")
 
         if (!pythonSetupPyFiles!!.all { it.exists() }) {
             logger.lifecycle("Ignored package build, because setup.py is not found")
@@ -86,7 +86,7 @@ class PythonBuildTask : AbstractTask() {
 
             pythonBuildDir?.deleteRecursively()
 
-            commands.add("python $setupFile $distType --dist-dir=$pythonBuildDir $uploadCommand".trim())
+            commands.add("$pythonExecutable $setupFile $distType --dist-dir=$pythonBuildDir $uploadCommand".trim())
 
             project.exec {
                 it.commandLine(listOf(

--- a/src/main/kotlin/com/innobead/gradle/task/PythonCompileTask.kt
+++ b/src/main/kotlin/com/innobead/gradle/task/PythonCompileTask.kt
@@ -28,7 +28,7 @@ class PythonCompileTask : AbstractTask() {
 
         logger.lifecycle("Compiling python scripts in source folders ($sourceDirs)")
 
-        val commands = mutableListOf("python -m compileall -f ${sourceDirs.joinToString(" ")}")
+        val commands = mutableListOf("$pythonExecutable -m compileall -f ${sourceDirs.joinToString(" ")}")
         project.exec {
             it.commandLine(listOf(
                     "bash", "-c",

--- a/src/main/kotlin/com/innobead/gradle/task/PythonDependenciesTask.kt
+++ b/src/main/kotlin/com/innobead/gradle/task/PythonDependenciesTask.kt
@@ -50,7 +50,7 @@ class PythonDependenciesTask : AbstractTask() {
             it.commandLine(listOf(
                     "bash", "-c",
                     "source $virtualenvDir/bin/activate; " +
-                            "python -m pip install -r requirements.txt $pipOptions"
+                            "$pythonExecutable -m pip install -r requirements.txt $pipOptions"
             ))
         }.rethrowFailure()
 
@@ -63,7 +63,7 @@ class PythonDependenciesTask : AbstractTask() {
             it.commandLine(listOf(
                     "bash", "-c",
                     "source $virtualenvDir/bin/activate; " +
-                            "python -m pip install -I --prefix='$libsDir' -r requirements.txt $pipOptions".trim()
+                            "$pythonExecutable -m pip install -I --prefix='$libsDir' -r requirements.txt $pipOptions".trim()
             ))
         }.rethrowFailure()
 

--- a/src/main/kotlin/com/innobead/gradle/task/PythonGrpcTask.kt
+++ b/src/main/kotlin/com/innobead/gradle/task/PythonGrpcTask.kt
@@ -55,8 +55,8 @@ class PythonGrpcTask : AbstractTask() {
             logger.lifecycle("Building gRPC Python client code based on the proto files from ${protoSourceDirs}")
 
             val commands = listOf(
-                    "python -m pip install grpcio==$grpcVersion grpcio-tools==$grpcVersion $pipOptions",
-                    "python -m grpc_tools.protoc ${protoSourceDirs!!.map { "-I$it" }.joinToString(" ")} " +
+                    "$pythonExecutable -m pip install grpcio==$grpcVersion grpcio-tools==$grpcVersion $pipOptions",
+                    "$pythonExecutable -m grpc_tools.protoc ${protoSourceDirs!!.map { "-I$it" }.joinToString(" ")} " +
                             "--python_out=$protoCodeGeneratedDir " +
                             "--grpc_python_out=$protoCodeGeneratedDir ${protoServiceProtoFiles!!.joinToString(" ")}"
             )

--- a/src/main/kotlin/com/innobead/gradle/task/PythonRuntimeTask.kt
+++ b/src/main/kotlin/com/innobead/gradle/task/PythonRuntimeTask.kt
@@ -37,7 +37,7 @@ class PythonRuntimeTask : AbstractTask() {
 
                 commands.addAll(listOf(
                         "curl -OL $url",
-                        "python get-pip.py -I --prefix $pythonDir",
+                        "$pythonExecutable get-pip.py -I --prefix $pythonDir",
                         "rm get-pip.py"
                 ))
 
@@ -78,7 +78,7 @@ class PythonRuntimeTask : AbstractTask() {
                 }
                 else -> {
                     commands.addAll(listOf(
-                            "python -m pip install virtualenv -I --prefix $pythonDir $pipOptions".trim()
+                            "$pythonExecutable -m pip install virtualenv -I --prefix $pythonDir $pipOptions".trim()
 
                     ))
 
@@ -128,9 +128,8 @@ class PythonRuntimeTask : AbstractTask() {
             it.standardOutput = NullOutputStream.INSTANCE
             it.errorOutput = NullOutputStream.INSTANCE
             it.args(listOf(
-
                     "-c",
-                    "python -m pip"
+                    "$pythonExecutable -m pip"
             ))
             it.isIgnoreExitValue = true
         }

--- a/src/main/kotlin/com/innobead/gradle/task/PythonTestTask.kt
+++ b/src/main/kotlin/com/innobead/gradle/task/PythonTestTask.kt
@@ -49,14 +49,14 @@ class PythonTestTask : AbstractTask() {
         val commands = mutableListOf<String>()
 
         if (project.file("requirements-test.txt").exists()) {
-            commands.add("python -m pip install -r ${project.file("requirements-test.txt").absolutePath} $pipOptions".trim())
+            commands.add("$pythonExecutable -m pip install -r ${project.file("requirements-test.txt").absolutePath} $pipOptions".trim())
         }
 
         commands.addAll(
                 listOf(
-                        "python -m pip install pytest pytest-cov",
+                        "$pythonExecutable -m pip install pytest pytest-cov",
                         "export PYTHONPATH='${sourceDirs.joinToString(":")}:\$PYTHONPATH'",
-                        "python -m pytest ${testSourceDirs.joinToString(" ")} " +
+                        "$pythonExecutable -m pytest ${testSourceDirs.joinToString(" ")} " +
                                 "--junit-xml=$testReportDir/junit-output.xml " +
                                 "${sourceCovDirs!!.map { "--cov=${it.absolutePath}" }.joinToString(" ")} " +
                                 "--cov-report term-missing " +


### PR DESCRIPTION
You can now specify `pythonExecutable` in your config to provide alternative python name (or full path) 