### PR TITLE
Update gradle version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,34 +1,34 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
-    kotlin("jvm") version "1.3.40"
+    kotlin("jvm") version "1.5.30"
     `java-gradle-plugin`
-    java
-    id("com.gradle.plugin-publish") version "0.10.0"
-    id("org.jetbrains.kotlin.plugin.allopen") version "1.3.40"
-    maven
+    `maven-publish`
+    id("com.gradle.plugin-publish") version "0.16.0"
+    id("org.jetbrains.kotlin.plugin.allopen") version "1.5.30"
 }
 
 group = "com.innobead"
-version = "1.3.7"
+version = "1.3.8-SNAPSHOT"
 
 repositories {
-    jcenter()
     mavenLocal()
     mavenCentral()
 }
 
 dependencies {
-    compile(gradleApi())
+    implementation(gradleApi())
 
-    compile(kotlin("stdlib"))
-    compile(kotlin("reflect"))
+    implementation(kotlin("stdlib"))
+    implementation(kotlin("reflect"))
 
-    testCompile(kotlin("test"))
-    testCompile("com.nhaarman:mockito-kotlin:1.4.0")
-    testCompile(kotlin("maven-allopen"))
+    testImplementation(kotlin("test"))
+    testImplementation("com.nhaarman:mockito-kotlin:1.6.0")
+    testImplementation(kotlin("maven-allopen"))
 
-    testRuntime("org.junit.platform:junit-platform-launcher:1.4.0")
-    testRuntime("org.junit.jupiter:junit-jupiter-engine:5.4.0")
-    testRuntime("org.junit.vintage:junit-vintage-engine:5.4.0")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.4.0")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.0")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.4.0")
 }
 
 allOpen {
@@ -61,6 +61,10 @@ pluginBundle {
         "pythonPlugin" {}
     }
 }
+
+val compileKotlin: KotlinCompile by tasks
+compileKotlin.kotlinOptions.apiVersion = "1.4"
+compileKotlin.kotlinOptions.jvmTarget = "11"
 
 afterEvaluate {
     val publishKey = System.getenv("GRADLE_PUBLISH_KEY")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/innobead/gradle/task/AbstractTask.kt
+++ b/src/main/kotlin/com/innobead/gradle/task/AbstractTask.kt
@@ -2,18 +2,23 @@ package com.innobead.gradle.task
 
 import com.innobead.gradle.plugin.pythonPluginExtension
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
 import java.io.File
 
 abstract class AbstractTask : DefaultTask() {
 
+    @get:InputFile
     val virtualenvDir by lazy {
         project.extensions.pythonPluginExtension.virtualenvDir
     }
 
+    @get:InputFile
     val pythonDir by lazy {
         project.extensions.pythonPluginExtension.pythonDir
     }
 
+    @get:InputFile
     val pythonBuildDir by lazy {
         project.extensions.pythonPluginExtension.pythonBuildDir
     }
@@ -30,6 +35,7 @@ abstract class AbstractTask : DefaultTask() {
         commands.add("""export PATH="$pythonDir/bin":${'$'}PATH""")
     }
 
+    @InputFile
     fun getPythonLibDir(): File? {
         var pythonLibDir: File? = null
 

--- a/src/main/kotlin/com/innobead/gradle/task/PythonBuildTask.kt
+++ b/src/main/kotlin/com/innobead/gradle/task/PythonBuildTask.kt
@@ -6,6 +6,9 @@ import com.innobead.gradle.plugin.pythonPluginExtension
 import com.innobead.gradle.plugin.taskName
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
@@ -17,18 +20,22 @@ class PythonBuildTask : AbstractTask() {
         val distTypeSupports = listOf("sdist", "bdist_wheel", "bdist_wheel --universal")
     }
 
+    @get:InputFiles
     val pythonSetupPyFiles by lazy {
         project.extensions.pythonPluginExtension.pythonSetupPyFiles
     }
 
+    @get:Input
     val pypiRepoUrl by lazy {
         project.extensions.pythonPluginExtension.pypiRepoUrl
     }
 
+    @get:Input
     val pypiRepoUsername by lazy {
         project.extensions.pythonPluginExtension.pypiRepoUsername
     }
 
+    @get:Input
     val pypiRepoPassword by lazy {
         project.extensions.pythonPluginExtension.pypiRepoPassword
     }

--- a/src/main/kotlin/com/innobead/gradle/task/PythonDependenciesTask.kt
+++ b/src/main/kotlin/com/innobead/gradle/task/PythonDependenciesTask.kt
@@ -4,6 +4,8 @@ import com.innobead.gradle.GradleSupport
 import com.innobead.gradle.plugin.PythonPlugin
 import com.innobead.gradle.plugin.pythonPluginExtension
 import com.innobead.gradle.plugin.taskName
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
@@ -11,14 +13,17 @@ import java.io.File
 @GradleSupport
 class PythonDependenciesTask : AbstractTask() {
 
+    @get:Input
     val pipOptions by lazy {
         project.extensions.pythonPluginExtension.pipOptions
     }
 
+    @get:Input
     val keepBuildCached by lazy {
         project.extensions.pythonPluginExtension.keepBuildCached
     }
 
+    @get:InputFile
     var copyLibsDir: File? = null
 
     init {

--- a/src/main/kotlin/com/innobead/gradle/task/PythonGrpcTask.kt
+++ b/src/main/kotlin/com/innobead/gradle/task/PythonGrpcTask.kt
@@ -5,6 +5,9 @@ import com.innobead.gradle.plugin.PythonPlugin
 import com.innobead.gradle.plugin.pythonPluginExtension
 import com.innobead.gradle.plugin.taskName
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
@@ -12,26 +15,32 @@ import java.io.File
 @GradleSupport
 class PythonGrpcTask : AbstractTask() {
 
+    @get:InputFiles
     val protoSourceDirs by lazy {
         project.extensions.pythonPluginExtension.protoSourceDirs
     }
 
+    @get:InputFiles
     val protoServiceProtoFiles by lazy {
         project.extensions.pythonPluginExtension.protoServiceProtoFiles
     }
 
+    @get:InputFile
     val protoCodeGeneratedDir by lazy {
         project.extensions.pythonPluginExtension.protoCodeGeneratedDir
     }
 
+    @get:Input
     val pipOptions by lazy {
         project.extensions.pythonPluginExtension.pipOptions
     }
 
+    @get:Input
     val grpcVersion by lazy {
         project.extensions.pythonPluginExtension.grpcVersion
     }
 
+    @get:Input
     val disableGrpc by lazy {
         project.extensions.pythonPluginExtension.disableGrpc
     }

--- a/src/main/kotlin/com/innobead/gradle/task/PythonRuntimeTask.kt
+++ b/src/main/kotlin/com/innobead/gradle/task/PythonRuntimeTask.kt
@@ -4,6 +4,7 @@ import com.innobead.gradle.GradleSupport
 import com.innobead.gradle.plugin.PythonPlugin
 import com.innobead.gradle.plugin.pythonPluginExtension
 import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.io.NullOutputStream
 
@@ -11,10 +12,12 @@ import org.gradle.internal.io.NullOutputStream
 @GradleSupport
 class PythonRuntimeTask : AbstractTask() {
 
+    @get:Input
     val pipOptions by lazy {
         project.extensions.pythonPluginExtension.pipOptions
     }
 
+    @get:Input
     val downloadUrls = listOf(
             "https://raw.githubusercontent.com/pypa/get-pip/master/get-pip.py",
             "https://bootstrap.pypa.io/get-pip.py"

--- a/src/main/kotlin/com/innobead/gradle/task/PythonTestTask.kt
+++ b/src/main/kotlin/com/innobead/gradle/task/PythonTestTask.kt
@@ -6,6 +6,8 @@ import com.innobead.gradle.plugin.PythonPluginExtension
 import com.innobead.gradle.plugin.pythonPluginExtension
 import com.innobead.gradle.plugin.taskName
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
@@ -13,10 +15,12 @@ import java.io.File
 @GradleSupport
 class PythonTestTask : AbstractTask() {
 
+    @get:InputFile
     val testReportDir by lazy {
         project.extensions.pythonPluginExtension.testReportDir
     }
 
+    @get:Input
     val pipOptions by lazy {
         project.extensions.pythonPluginExtension.pipOptions
     }


### PR DESCRIPTION
The new gradle versions after 7 give this error when executing tasks in pygradle
```
   - Error: Type 'com.innobead.gradle.task.PythonTestTask' property 'virtualenvDir' is missing an input or output annotation.
      
      Reason: A property without annotation isn't considered during up-to-date checking.
      
      Possible solutions:
        1. Add an input or output annotation.
        2. Mark it as @Internal.
      
      Please refer to https://docs.gradle.org/7.2/userguide/validation_problems.html#missing_annotation for more details about this problem.
  See https://docs.gradle.org/7.2/userguide/more_about_tasks.html#sec:task_input_output_annotations for more information on how to annotate task properties.

```
Also bumped up the Kotlin version