### PR TITLE
Target java 11 bytecode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,10 @@ repositories {
     mavenCentral()
 }
 
+java {
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
 dependencies {
     implementation(gradleApi())
 


### PR DESCRIPTION
Add the build target to the gradle compile so the library can execute in a gradle running java 11

Without it, you'll get a big error like this 
```
      > No matching variant of com.innobead:gradle-python-plugin:1.4.1 was found. The consumer was configured to find a runtime of a library compatible with Java 11, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '7.3' but:
          - Variant 'apiElements' capability com.innobead:gradle-python-plugin:1.4.1 declares a library, packaged as a jar, and its dependencies declared externally:
              - Incompatible because this component declares an API of a component compatible with Java 17 and the consumer needed a runtime of a component compatible with Java 11
              - Other compatible attribute:
                  - Doesn't say anything about org.gradle.plugin.api-version (required '7.3')
```